### PR TITLE
tempest: fix virtenv installation

### DIFF
--- a/roles/tempest/files/install_venv.sh
+++ b/roles/tempest/files/install_venv.sh
@@ -23,7 +23,11 @@ main() {
 
     local py_version=$(python --version 2>&1)
     if [[ $py_version =~ "2.7" ]]; then
-        source .venv/bin/activate
+        ### HACK: turn off: "treat unset variable as error" {
+            set +u
+            source .venv/bin/activate
+            set -u
+        ### }
         pip install junitxml >/dev/null 2>&1 ||
             pip install junitxml >/dev/null 2>&1 ||
             pip install junitxml >/dev/null 2>&1 || {


### PR DESCRIPTION
The install_venv.sh script has set -e and -u but sourcing
venv/bin/activate results in the error below
  line 8: _OLD_VIRTUAL_PATH: unbound variable
The fix turns off -u temporarily to source the 'activate' file
